### PR TITLE
Make node module context-aware to allow usage in worker threads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ build-wrapper:
 
 test: tests/data/text8-vector.json
 	node tests/smalltest.js
+	node tests/worker-thread-test.js
 	node tests/smalltest-manhattan.js
 	node tests/basictests.js basic-config.js
 

--- a/addon.cc
+++ b/addon.cc
@@ -5,4 +5,6 @@ void InitAll(v8::Local<v8::Object> exports) {
   AnnoyIndexWrapper::Init(exports);
 }
 
-NODE_MODULE(addon, InitAll)
+NODE_MODULE_INIT() {
+    InitAll(exports);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -651,6 +651,11 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
       "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
     },
+    "node-worker-threads-pool": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/node-worker-threads-pool/-/node-worker-threads-pool-1.5.1.tgz",
+      "integrity": "sha512-7TXAhpMm+jO4MfESxYLtMGSnJWv+itdNHMdaFmeZuPXxwFGU90mtEB42BciUULXOUAxYBfXILAuvrSG3rQZ7mw=="
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "bindings": "^1.2.1",
     "level": "^6.0.0",
-    "nan": "^2.14.0"
+    "nan": "^2.14.0",
+    "node-worker-threads-pool": "^1.5.1"
   }
 }

--- a/tests/testworker.js
+++ b/tests/testworker.js
@@ -1,0 +1,18 @@
+const { parentPort } = require('worker_threads');
+var Annoy = require('../index');
+
+var annoyPath = __dirname + '/data/test.annoy';
+
+const annoyIndex = new Annoy(10, 'Angular')
+
+if(!annoyIndex.load(annoyPath)) {
+    throw new Error('Loading annoy index failed!')
+} else {
+    console.log('Successfully loaded annoy index.')
+}
+
+parentPort.on('message', async (id) => {
+    // return the result to the main thread
+    const result = annoyIndex.getNNsByItem(id, 10, -1, false)
+    parentPort.postMessage(result);
+});

--- a/tests/worker-thread-test.js
+++ b/tests/worker-thread-test.js
@@ -1,0 +1,19 @@
+var test = require('tape');
+const { StaticPool } = require('node-worker-threads-pool')
+
+var workerPath = __dirname + '/testworker.js';
+
+test('Worker thread test', workerThreadTest);
+
+async function workerThreadTest(t) {
+    const workerPool = new StaticPool({
+        size: 2,
+        task: workerPath
+    });
+
+    const idsToLookUp = [0, 1]
+    const indexLookups = idsToLookUp.map(id => workerPool.exec(id))
+    console.log("Lookup results: ", (await Promise.all(indexLookups)))
+    workerPool.destroy()
+    t.end()
+}


### PR DESCRIPTION
Thanks for building and maintaining this module, works great! :)

I came across an issue when trying to perform index lookups on multiple node worker threads:

`Error: Module did not self-register: '/usr/src/app/annoy-node/build/Release/addon.node'.
     at Object.Module._extensions..node (node:internal/modules/cjs/loader:1187:18)
     at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
     at Module.require (node:internal/modules/cjs/loader:1005:19)
     at require (node:internal/modules/cjs/helpers:102:18)
     at bindings (/usr/src/app/node_modules/bindings/bindings.js:112:48)
     at Object.<anonymous> (/usr/src/app/annoy-node/index.js:1:37)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1157:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
 Emitted 'error' event on PoolWorker instance at:
     at PoolWorker.[kOnErrorMessage] (node:internal/worker:289:10)
     at PoolWorker.[kOnMessage] (node:internal/worker:300:37)
     at MessagePort.<anonymous> (node:internal/worker:201:57)
     at MessagePort.[nodejs.internal.kHybridDispatch] (node:internal/event_target:647:20)
     at MessagePort.exports.emitMessage (node:internal/per_context/messageport:23:28) {
   code: 'ERR_DLOPEN_FAILED'
 }`

I found a fix for the issue in this thread: https://github.com/nodejs/node/issues/21783#issuecomment-429637117 Apparently, the module hast to be declared in a context-aware manner to be loaded multiple times in the same process. With the changes in this PR, using the index on multiple worker threads works fine.